### PR TITLE
Remove remaining hardcoded credentials and document required env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
-# Copy to .env and set a strong random value before running compose.
+# Copy to .env and set strong random values before running compose.
 MYSQL_ROOT_PASSWORD=change-me-to-a-strong-random-password
+DB_USER=change-me
+DB_PASSWORD=change-me-to-a-strong-random-password
+RDS_PASSWORD=change-me-to-a-strong-random-password

--- a/src/main/webapp/WEB-INF/config.properties
+++ b/src/main/webapp/WEB-INF/config.properties
@@ -2,8 +2,8 @@
 # To change this template file, choose Tools | Templates
 # and open the template in the editor.
 
-dbuser=root
-dbpass=root
+dbuser=${DB_USER}
+dbpass=${DB_PASSWORD}
 dbname=abc
 dburl=jdbc:mysql://mysql:3306/
 jdbcdriver=com.mysql.jdbc.Driver


### PR DESCRIPTION
## Summary
- `config.properties`: replace hardcoded `dbuser=root` / `dbpass=root` with env var placeholders `${DB_USER}` / `${DB_PASSWORD}`
- `.env.example`: document all required environment secrets (`MYSQL_ROOT_PASSWORD`, `DB_USER`, `DB_PASSWORD`, `RDS_PASSWORD`)

## Context
Previous PRs #60 and #61 resolved critical hardcoded secrets in `rds.tf`, `rds.java`, `users.xml`, and `docker-compose.yml`. This PR addresses the remaining hardcoded credentials in `config.properties` and consolidates all required env vars in `.env.example` for developer reference.

## Apiiro Risks Addressed
- Remaining hardcoded DB credentials in `config.properties`
- All critical secret risks from Apiiro scan now remediated across the codebase

## Test plan
- [ ] Verify `config.properties` no longer contains hardcoded credentials
- [ ] Confirm `.env.example` documents all secrets needed to run the app
- [ ] Set env vars and verify app starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)