### PR TITLE
Fix SQL injection in LoginValidator

### DIFF
--- a/src/main/java/org/cysecurity/cspf/jvl/controller/LoginValidator.java
+++ b/src/main/java/org/cysecurity/cspf/jvl/controller/LoginValidator.java
@@ -9,8 +9,8 @@ package org.cysecurity.cspf.jvl.controller;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServlet;
@@ -48,8 +48,10 @@ public class LoginValidator extends HttpServlet {
                     if(con!=null && !con.isClosed())
                                {
                                    ResultSet rs=null;
-                                   Statement stmt = con.createStatement();  
-                                   rs=stmt.executeQuery("select * from users where username='"+user+"' and password='"+pass+"'");
+                                   PreparedStatement stmt = con.prepareStatement("select * from users where username=? and password=?");
+                                   stmt.setString(1, user);
+                                   stmt.setString(2, pass);
+                                   rs=stmt.executeQuery();
                                    if(rs != null && rs.next()){
                                    HttpSession session=request.getSession();
                                    session.setAttribute("isLoggedIn", "1");


### PR DESCRIPTION
## Summary
- Replace string-concatenated `Statement` query with parameterized `PreparedStatement` in `LoginValidator.java`
- Eliminates SQL injection vulnerability on the login endpoint (`/login.jsp`)

## Changes
- `import java.sql.Statement` → `import java.sql.PreparedStatement`
- Query `"select * from users where username='"+user+"' and password='"+pass+"'"` replaced with `?` placeholders and `setString()` bindings

## Apiiro Risks Addressed
- 9 SQL Injection findings (High) in `LoginValidator.java` lines 51–52

## Test plan
- [ ] Verify login with valid credentials still works
- [ ] Verify SQL injection payloads (e.g. `' OR '1'='1`) are rejected
- [ ] Confirm no new risks introduced (Apiiro pre-commit scan: 0 new risks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)